### PR TITLE
ci: run semantic commit check against PR title

### DIFF
--- a/.github/workflows/semantic-pr-check.yml
+++ b/.github/workflows/semantic-pr-check.yml
@@ -1,0 +1,21 @@
+name: Semantic PR check
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+permissions:
+  pull-requests: read
+
+jobs:
+  main:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check semantic PR title
+        uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This repository enforces [semantic commit messages](https://www.conventionalcommits.org) to help automate the release process. It is important that the title of a PR follows this standard for the case where we squash merge and that title becomes the commit message that goes back into main/master.