### PR TITLE
build: update commitlint config

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,4 +1,8 @@
 module.exports = {
   extends: ['@commitlint/config-conventional'],
-  rules: { 'body-max-line-length': [0] },
+  ignores: [(commit) => commit.startsWith('chore(release):')],
+  rules: {
+    'footer-max-line-length': [0],
+    'body-max-line-length': [0],
+  },
 };


### PR DESCRIPTION
These [rules](https://commitlint.js.org/reference/rules.html) can cause issues when we want to write a long commit message, for example, when documenting a breaking change.